### PR TITLE
Add ability to enter custom NPC bonus XP multipliers in plugin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.25'
+def runeLiteVersion = '1.9.7'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
@@ -28,4 +28,13 @@ public interface InstantDamageCalculatorConfig extends Config
     {
         return false;
     }
+
+    @ConfigItem(
+            keyName = "customBonusXP",
+            name = "Custom NPC Bonus XP",
+            description = "Add bonus XP modifiers for custom NPCs. Format is id:multiplier eg. \"12345:1.05\", once per line.",
+            position = 2
+    )
+    default String customBonusXP() { return "// Phantom Muspah\n12077 : 2.075\n12078 : 2.075\n12079 : 2.075\n12080 : 2.075\n12082 : 2.075"; }
+
 }

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -44,8 +44,8 @@ public class InstantDamageCalculatorPlugin extends Plugin
 
 	private int xp = -1;
 	private NPCWithXpBoost lastOpponent;
-
 	private int lastOpponentID = -1;
+
 	@Getter
 	private int hit = 0;
 	private int mode = 0;
@@ -110,7 +110,8 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	@Override
-	protected void startUp() throws Exception {
+	protected void startUp() throws Exception
+	{
 		overlayManager.add(overlay);
 		reloadCustomXP();
 
@@ -126,7 +127,8 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onConfigChanged(ConfigChanged configChanged) {
+	public void onConfigChanged(ConfigChanged configChanged)
+	{
 		if (configChanged.getKey().equals("customBonusXP")) {
 			reloadCustomXP();
 		}
@@ -280,7 +282,8 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 	}
 
-	private void reloadCustomXP() {
+	private void reloadCustomXP()
+	{
 		CUSTOM_XP_MODIFIERS.clear();
 
 		for (String customRaw : config.customBonusXP().split("\n"))

--- a/src/main/java/com/geeckon/instantdamagecalculator/NPCWithXpBoost.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/NPCWithXpBoost.java
@@ -74,9 +74,5 @@ public enum NPCWithXpBoost {
 
         return null;
     }
-
-    void reloadCustomXP() {
-
-    };
     
 }

--- a/src/main/java/com/geeckon/instantdamagecalculator/NPCWithXpBoost.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/NPCWithXpBoost.java
@@ -74,5 +74,9 @@ public enum NPCWithXpBoost {
 
         return null;
     }
+
+    void reloadCustomXP() {
+
+    };
     
 }


### PR DESCRIPTION
As new NPCs are added to the game, the plugin needs to be updated to include their XP modifiers in order to accurately calculate the damage dealt. An alternative that requires less maintenance is to simply allow users to enter the multipliers themselves as needed.

Entering NPC IDs as opposed to NPC names allows the user to differentiate between a boss' different phases or different variants of the same NPC , that may have different multipliers.

The default value for the new field includes an example for adding a multiplier to the newest boss, Phantom Muspah.