### PR TITLE
Reduce Scope of resetOnOpponentChange & Exclusions to Muspah Only

### DIFF
--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
@@ -78,18 +78,10 @@ public interface InstantDamageCalculatorConfig extends Config
     default String customBonusXP() { return "// Phantom Muspah\n12077 : 2.075\n12078 : 2.075\n12079 : 2.075\n12080 : 2.075\n12082 : 2.075"; }
 
     @ConfigItem(
-            keyName = "excludedNpcIDs",
-            name = "Excluded NPC IDs",
-            description = "NPC IDs to exclude from damage totalling. Enter one NPC ID per line.<br>If resetting on opponent change is enabled, attacking an excluded NPC will not reset total dmg.",
-            position = 7
-    )
-    default String excludedNpcIDs() { return ""; }
-
-    @ConfigItem(
             keyName = "displayTotalDamageOverlay",
             name = "Display total damage overlay",
             description = "If enabled, an overlay is displayed which shows the total damage done, including the current hit. This total can then be reset using one of the following configurations. Can be useful for the Phantom Muspah boss",
-            position = 8
+            position = 7
     )
     default boolean displayTotalDamageOverlay()
     {
@@ -100,7 +92,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnWeaponChange",
             name = "Reset total damage on weapon change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the equipped weapon is changed",
-            position = 9
+            position = 8
     )
     default boolean resetOnWeaponChange()
     {
@@ -111,7 +103,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnPrayerChange",
             name = "Reset total damage on prayer change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player activates a protection prayer different from the one they previously activated",
-            position = 10
+            position = 9
     )
     default boolean resetOnPrayerChange()
     {
@@ -122,7 +114,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnBarrowsCryptEntry",
             name = "Reset total damage on Barrows Crypt entry",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player enters a Barrows crypt",
-            position = 11
+            position = 10
     )
     default boolean resetOnBarrowsCryptEntry()
     {
@@ -130,12 +122,12 @@ public interface InstantDamageCalculatorConfig extends Config
     }
 
     @ConfigItem(
-            keyName = "resetOnOpponentChange",
-            name = "Reset total damage on opponent change",
-            description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player changes opponent",
-            position = 12
+            keyName = "resetOnMuspahPhase",
+            name = "Reset total damage on Muspah phase change",
+            description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever Muspah phase changes and will ignore teleport phase",
+            position = 11
     )
-    default boolean resetOnOpponentChange()
+    default boolean resetOnMuspahPhase()
     {
         return false;
     }

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -49,7 +49,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	private int xp = -1;
 	private NPCWithXpBoost lastOpponent;
 	private int lastOpponentID = -1;
-	private int lastValidOpponentID = -1;
+	private int lastMuspahPhase = -1;
 
 	@Getter
 	private double hit = 0;
@@ -296,6 +296,9 @@ public class InstantDamageCalculatorPlugin extends Plugin
 
 	private HashMap<Integer, Double> CUSTOM_XP_MODIFIERS = new HashMap<Integer, Double>();
 
+	private static final List<Integer> MUSPAH_IDS = new ArrayList<>(Arrays.asList(NpcID.PHANTOM_MUSPAH,
+			NpcID.PHANTOM_MUSPAH_12078, NpcID.PHANTOM_MUSPAH_12079, NpcID.PHANTOM_MUSPAH_12080, NpcID.PHANTOM_MUSPAH_12082));
+
 	private Instant expiryTimer;
 
 	@Getter
@@ -318,7 +321,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception {
 		overlayManager.remove(overlay);
-		lastValidOpponentID = -1;
+		lastMuspahPhase = -1;
 		lastOpponentID = -1;
 		lastOpponent = null;
 
@@ -404,6 +407,10 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	private void handleHitpointsXpDrop(long diff) {
+		if (config.resetOnMuspahPhase() && lastOpponentID == NpcID.PHANTOM_MUSPAH_12082) {
+			return;
+		}
+
 		double modifier = 1.0;
 
 		if(CUSTOM_XP_MODIFIERS.containsKey(lastOpponentID))
@@ -424,17 +431,17 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 
 		hit = roundToPrecision(diff / 1.33 / modifier);
-		if (config.resetOnMuspahPhase() && NpcID.PHANTOM_MUSPAH_12082 != lastOpponentID) {
-			totalHit = roundToPrecision(totalHit + hit);
-		}
+		totalHit = roundToPrecision(totalHit + hit);
 
 		enableExpiryTimer();
 	}
 
 	@Subscribe
 	public void onNpcChanged(NpcChanged event) {
-		if (event.getOld().getId() == lastOpponentID) {
-			handleOpponentUpdate(event.getNpc());
+		int oldNpcID = event.getOld().getId();
+		int newNpcId = event.getNpc().getId();
+		if (config.resetOnMuspahPhase() && MUSPAH_IDS.contains(oldNpcID) && oldNpcID == lastMuspahPhase) {
+			handleMuspahUpdate(newNpcId);
 		}
 	}
 
@@ -455,19 +462,22 @@ public class InstantDamageCalculatorPlugin extends Plugin
 
 		NPC npc = (NPC) opponent;
 
-		handleOpponentUpdate(npc);
-	}
-
-	private void handleOpponentUpdate(NPC npc) {
 		lastOpponentID = npc.getId();
 		lastOpponent = NPCWithXpBoost.getNpc(lastOpponentID);
 
-		// only reset total dmg if attacking a new, non-excluded NPC ID
-		if (NpcID.PHANTOM_MUSPAH_12082 != npc.getId()) {
-			if (config.resetOnMuspahPhase() && lastValidOpponentID != npc.getId()) {
+		if (config.resetOnMuspahPhase() && MUSPAH_IDS.contains(npc.getId())) {
+			handleMuspahUpdate(npc.getId());
+		}
+	}
+
+	private void handleMuspahUpdate(int muspahID) {
+		if (muspahID == NpcID.PHANTOM_MUSPAH || muspahID == NpcID.PHANTOM_MUSPAH_12078) {
+			if (lastMuspahPhase != muspahID) {
 				resetTotalHit();
+				lastMuspahPhase = muspahID;
 			}
-			lastValidOpponentID = npc.getId();
+		} else if (muspahID == NpcID.PHANTOM_MUSPAH_12079 || muspahID == NpcID.PHANTOM_MUSPAH_12080) {
+			lastMuspahPhase = -1;
 		}
 	}
 


### PR DESCRIPTION
As [requested by the RuneLite admins/reviewers](https://github.com/runelite/plugin-hub/pull/7615#issuecomment-2711885515), this PR reduces the scope of the previously proposed resetOnOpponentChange to only affect Muspah, instead of any NPC generically. Also, the excludedNpcIDs config feature has been removed, instead Muspah's teleport phase is a hard coded exception.

dayoh — Today at 4:39 PM
> I saw your comment on my PR, I see what you mean how making this generic allows for potential abuse.
> 
> Just to confirm before I spend time reworking this, are you saying that the ability to reset the overlay when the NPC your attacking changes and ignoring specific NPCs is fine as long as they're hard-coded? Specifically I would just do this for the Phantom Muspah use-case

Nightfirecat — Today at 4:46 PM
> Yes that's correct