### PR TITLE
Reduce Scope of resetOnOpponentChange & Exclusions to Muspah Only

### DIFF
--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
@@ -78,18 +78,10 @@ public interface InstantDamageCalculatorConfig extends Config
     default String customBonusXP() { return "// Phantom Muspah\n12077 : 2.075\n12078 : 2.075\n12079 : 2.075\n12080 : 2.075\n12082 : 2.075"; }
 
     @ConfigItem(
-            keyName = "excludedNpcIDs",
-            name = "Excluded NPC IDs",
-            description = "NPC IDs to exclude from damage totalling. Enter one NPC ID per line.<br>If resetting on opponent change is enabled, attacking an excluded NPC will not reset total dmg.",
-            position = 7
-    )
-    default String excludedNpcIDs() { return ""; }
-
-    @ConfigItem(
             keyName = "displayTotalDamageOverlay",
             name = "Display total damage overlay",
             description = "If enabled, an overlay is displayed which shows the total damage done, including the current hit. This total can then be reset using one of the following configurations. Can be useful for the Phantom Muspah boss",
-            position = 8
+            position = 7
     )
     default boolean displayTotalDamageOverlay()
     {
@@ -100,7 +92,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnWeaponChange",
             name = "Reset total damage on weapon change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the equipped weapon is changed",
-            position = 9
+            position = 8
     )
     default boolean resetOnWeaponChange()
     {
@@ -111,7 +103,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnPrayerChange",
             name = "Reset total damage on prayer change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player activates a protection prayer different from the one they previously activated",
-            position = 10
+            position = 9
     )
     default boolean resetOnPrayerChange()
     {
@@ -122,7 +114,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnBarrowsCryptEntry",
             name = "Reset total damage on Barrows Crypt entry",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player enters a Barrows crypt",
-            position = 11
+            position = 10
     )
     default boolean resetOnBarrowsCryptEntry()
     {
@@ -130,12 +122,12 @@ public interface InstantDamageCalculatorConfig extends Config
     }
 
     @ConfigItem(
-            keyName = "resetOnOpponentChange",
-            name = "Reset total damage on opponent change",
-            description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player changes opponent",
-            position = 12
+            keyName = "resetOnMuspahPhase",
+            name = "Reset total damage on Muspah phase change",
+            description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever Muspah phase changes and will ignore teleport phase",
+            position = 11
     )
-    default boolean resetOnOpponentChange()
+    default boolean resetOnMuspahPhase()
     {
         return false;
     }

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorConfig.java
@@ -89,10 +89,21 @@ public interface InstantDamageCalculatorConfig extends Config
     }
 
     @ConfigItem(
+            keyName = "clearTotalOnOverlayExpiry",
+            name = "Clear total damage on overlay expiry",
+            description = "If enabled, the total damage counter will be set to 0 when the overlay expires.",
+            position = 8
+    )
+    default boolean clearTotalOnOverlayExpiry()
+    {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "resetOnWeaponChange",
             name = "Reset total damage on weapon change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the equipped weapon is changed",
-            position = 8
+            position = 9
     )
     default boolean resetOnWeaponChange()
     {
@@ -103,7 +114,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnPrayerChange",
             name = "Reset total damage on prayer change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player activates a protection prayer different from the one they previously activated",
-            position = 9
+            position = 10
     )
     default boolean resetOnPrayerChange()
     {
@@ -114,7 +125,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnBarrowsCryptEntry",
             name = "Reset total damage on Barrows Crypt entry",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever the player enters a Barrows crypt",
-            position = 10
+            position = 11
     )
     default boolean resetOnBarrowsCryptEntry()
     {
@@ -125,7 +136,7 @@ public interface InstantDamageCalculatorConfig extends Config
             keyName = "resetOnMuspahPhase",
             name = "Reset total damage on Muspah phase change",
             description = "If enabled with the \"Display total damage overlay\" setting, total damage will be reset whenever Muspah phase changes and will ignore teleport phase",
-            position = 11
+            position = 12
     )
     default boolean resetOnMuspahPhase()
     {

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -612,9 +612,10 @@ public class InstantDamageCalculatorPlugin extends Plugin
 			resetTotalHit();
 		}
 	}
+
 	private void resetTotalHit() {
 		totalHit = 0;
-  }
+	}
 
 	private void updateToaModifiers()
 	{
@@ -782,6 +783,9 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	private void expireOverlay()
 	{
 		overlayExpired = true;
+		if (config.clearTotalOnOverlayExpiry()) {
+			resetTotalHit();
+		}
 	}
 
 	private void enableExpiryTimer()

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -473,11 +473,13 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	private void handleMuspahUpdate(int muspahID) {
+		// Muspah is in Range or Melee phase
 		if (muspahID == NpcID.PHANTOM_MUSPAH || muspahID == NpcID.PHANTOM_MUSPAH_12078) {
 			if (lastMuspahPhase != muspahID) {
 				resetTotalHit();
 				lastMuspahPhase = muspahID;
 			}
+		// Muspah is in Shield or Last Stand phase
 		} else if (muspahID == NpcID.PHANTOM_MUSPAH_12079 || muspahID == NpcID.PHANTOM_MUSPAH_12080) {
 			lastMuspahPhase = -1;
 		}

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -406,7 +406,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 	}
 
-	private boolean isBlockedByMuspahConfig() {
+	private boolean shouldIncludeTotalHit() {
 		return !config.resetOnMuspahPhase() || lastOpponentID != NpcID.PHANTOM_MUSPAH_12082;
 	}
 
@@ -431,7 +431,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 
 		hit = roundToPrecision(diff / 1.33 / modifier);
-		if (isBlockedByMuspahConfig()) {
+		if (shouldIncludeTotalHit()) {
 			totalHit = roundToPrecision(totalHit + hit);
 		}
 

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -442,6 +442,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	public void onNpcChanged(NpcChanged event) {
 		int oldNpcID = event.getOld().getId();
 		int newNpcId = event.getNpc().getId();
+		// Only pass NPC change information on if it's related to muspah change
 		if (config.resetOnMuspahPhase() && MUSPAH_IDS.contains(oldNpcID) && oldNpcID == lastMuspahPhase) {
 			lastOpponentID = newNpcId;
 			lastOpponent = NPCWithXpBoost.getNpc(lastOpponentID);
@@ -475,7 +476,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	private void handleMuspahUpdate(int muspahID) {
-		// Muspah is in Range or Melee phase
+		// Muspah changed between Range or Melee phase
 		if (muspahID == NpcID.PHANTOM_MUSPAH || muspahID == NpcID.PHANTOM_MUSPAH_12078) {
 			if (lastMuspahPhase != muspahID) {
 				resetTotalHit();

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -407,10 +407,6 @@ public class InstantDamageCalculatorPlugin extends Plugin
 	}
 
 	private void handleHitpointsXpDrop(long diff) {
-		if (config.resetOnMuspahPhase() && lastOpponentID == NpcID.PHANTOM_MUSPAH_12082) {
-			return;
-		}
-
 		double modifier = 1.0;
 
 		if(CUSTOM_XP_MODIFIERS.containsKey(lastOpponentID))
@@ -431,7 +427,9 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 
 		hit = roundToPrecision(diff / 1.33 / modifier);
-		totalHit = roundToPrecision(totalHit + hit);
+		if (!config.resetOnMuspahPhase() || lastOpponentID != NpcID.PHANTOM_MUSPAH_12082) {
+			totalHit = roundToPrecision(totalHit + hit);
+		}
 
 		enableExpiryTimer();
 	}

--- a/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
+++ b/src/main/java/com/geeckon/instantdamagecalculator/InstantDamageCalculatorPlugin.java
@@ -406,6 +406,10 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 	}
 
+	private boolean isBlockedByMuspahConfig() {
+		return !config.resetOnMuspahPhase() || lastOpponentID != NpcID.PHANTOM_MUSPAH_12082;
+	}
+
 	private void handleHitpointsXpDrop(long diff) {
 		double modifier = 1.0;
 
@@ -427,7 +431,7 @@ public class InstantDamageCalculatorPlugin extends Plugin
 		}
 
 		hit = roundToPrecision(diff / 1.33 / modifier);
-		if (!config.resetOnMuspahPhase() || lastOpponentID != NpcID.PHANTOM_MUSPAH_12082) {
+		if (isBlockedByMuspahConfig()) {
 			totalHit = roundToPrecision(totalHit + hit);
 		}
 


### PR DESCRIPTION
As [requested by the RuneLite admins/reviewers](https://github.com/runelite/plugin-hub/pull/7615#issuecomment-2711885515), this PR reduces the scope of the previously proposed resetOnOpponentChange to only affect Muspah, instead of any NPC generically. Also, the excludedNpcIDs config feature has been removed, instead Muspah's teleport phase is a hard coded exception.

dayoh — Today at 4:39 PM


> I saw your comment on my PR, I see what you mean how making this generic allows for potential abuse.
> 
> Just to confirm before I spend time reworking this, are you saying that the ability to reset the overlay when the NPC your attacking changes and ignoring specific NPCs is fine as long as they're hard-coded? Specifically I would just do this for the Phantom Muspah use-case
> 

Nightfirecat — Today at 4:46 PM

> Yes that's correct

Also I added an option to clear total damage on overlay expiry. I saw that it can be frustrating if you die or tele out, but still have your old damage counter. This way, if players want to enable this setting, they can have their total damage reset so they are starting on a blank slate for the next kill if they died/tele'd out (depending on their expiry timeout value).